### PR TITLE
fix: show warning on duplicated ModalContainer instances for same scope name.

### DIFF
--- a/src/utils/register-scope.ts
+++ b/src/utils/register-scope.ts
@@ -15,6 +15,9 @@ if (typeof window !== 'undefined') {
 }
 
 export const registerContainer = (scope: Scope, ref: ContainerRef) => {
+  if (window[SCOPE_KEY][scope]) {
+    console.warn('Duplicated scope detected, scope: ' + scope + ' has already been registered, multiple instance of ModalContainer may cause unpredictable behaviors!')
+  }
   window[SCOPE_KEY][scope] = ref
 
   return ref


### PR DESCRIPTION
Add warning when user renders multiple ModalContainer with same or no scope.
If one of the ModalContainer is unregistered, modals with that scope name won't be shown until next time the ModalContainer of the same scope name is rendered again.